### PR TITLE
Amend campus mailing list urls.

### DIFF
--- a/campus-resources.md
+++ b/campus-resources.md
@@ -17,13 +17,13 @@ public-facing web standards guide. The site is hosted on the
 [UCSB IT Web site](http://it.ucsb.edu/) (login required) and
 provides additional depth and specifics on many topics covered in the guide.
 
-### [UCSB-Web Mailing List](https://lists.ucsb.edu/mailman/listinfo/ucsb-web)
+### [UCSB-Web Mailing List](https://lists.noc.ucsb.edu/mailman/listinfo/ucsb-web)
 
 Provides a forum for UCSB web professionals to exchange information about web
 design, development, best practices, and other web-related topics at UCSB. Web
 Standards Group meeting and event notices are also distributed via this list.
 
-### [Computer Support Forum (CSF) Mailing List](https://lists.ucsb.edu/mailman/listinfo/csf)
+### [Computer Support Forum (CSF) Mailing List](https://lists.noc.ucsb.edu/mailman/listinfo/csf)
 
 Provides a means for UCSB computer support staff to exchange questions,
 answers, and information in support of computing at UCSB.


### PR DESCRIPTION
Kevin Schmidt sent out an email and dictated a URL change for the
campus mailing list and these changes amend the URLs to the new
format. His message was:

> The CSF mailing list will experience a small change on March 24th,
> between 8:00-9:00am.  As you may have noticed, messages to csf@ucsb.edu
> are forwarded to csf@lists.ucsb.edu for delivery.  This also means the
> CSF mailing list page, https://lists.ucsb.edu/mailman/listinfo/csf,
> has been at a "lists.ucsb.edu" address.  The lists.ucsb.edu name is
> being reassigned to another server for use with other mailing lists.  To
> facilitate this change, mailing lists on lists.ucsb.edu will move to
> lists.noc.ucsb.edu on March 24th.

This fixes ucsb-wsg/ucsb-wsg.github.io#11
This closes ucsb-wsg/ucsb-wsg.github.io#11
