### PR TITLE
Change URL of Best Practice Examples intro page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ navigation:
         url: campus-resources/
       -
         text: "Best Practices Examples"
-        url: best-practice-examples/
+        url: examples/
       -
         text: "Web Standards Checklist"
         url: web-standards-checklist/

--- a/examples.md
+++ b/examples.md
@@ -1,5 +1,5 @@
 ---
 layout: default
 title: Best Practice Examples
-permalink: /best-practice-examples/
+permalink: /examples/
 ---


### PR DESCRIPTION
From "/best-practice-examples" to "/examples"

Fixes #24
