### PR TITLE
Revert Best Practice Examples Intro URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ navigation:
         url: campus-resources/
       -
         text: "Best Practices Examples"
-        url: examples/
+        url: best-practice-examples/
       -
         text: "Web Standards Checklist"
         url: web-standards-checklist/

--- a/best-practice-examples.md
+++ b/best-practice-examples.md
@@ -1,5 +1,5 @@
 ---
 layout: default
 title: Best Practice Examples
-permalink: /examples/
+permalink: /best-practice-examples/
 ---


### PR DESCRIPTION
Hey there!

So I actually got this mixed up: I thought we were renaming the intro page and _not_ the repo. Since we ended up renaming the repo, I swapped the page back to the original URL.

(Fixes my previous bad fix for #24)
