### PR TITLE
Examples Page, Renamed "Best Practice Examples"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,9 @@ navigation:
         text: "Campus Resources"
         url: campus-resources/
       -
+        text: "Examples"
+        url: examples/
+      -
         text: "Best Practices Examples"
         url: best-practice-examples/
       -

--- a/_config.yml
+++ b/_config.yml
@@ -87,8 +87,8 @@ navigation:
         text: "Examples"
         url: examples/
       -
-        text: "Best Practices Examples"
-        url: best-practice-examples/
+        text: "Best Practices Templates"
+        url: best-practice-templates/
       -
         text: "Web Standards Checklist"
         url: web-standards-checklist/

--- a/best-practice-examples.md
+++ b/best-practice-examples.md
@@ -1,5 +1,0 @@
----
-layout: default
-title: Best Practice Examples
-permalink: /best-practice-examples/
----

--- a/best-practice-templates.md
+++ b/best-practice-templates.md
@@ -1,0 +1,5 @@
+---
+layout: default
+title: Best Practice Templates
+permalink: /best-practice-templates/
+---

--- a/examples.md
+++ b/examples.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Examples
+permalink: /examples/
+---
+
+The following websites are examples of **high-traffic, high-profile** websites
+that adhere to the best practices outlined in the Web Standards Guide:
+
+### Campus-wide Services
+
+* [Admissions](http://admissions.sa.ucsb.edu/)
+* [Office of the Registrar](http://registrar.sa.ucsb.edu/)
+* [Library](http://www.library.ucsb.edu/)
+* [Division of Student Affairs](http://www.sa.ucsb.edu/)
+* [Graduate Division](http://www.graddiv.ucsb.edu/)
+
+### Major Academic Units
+
+* [College of Engineering](http://engineering.ucsb.edu/)
+* [College of Letters and Science](http://www.ltsc.ucsb.edu/)
+* [College of Creative Studies](https://ccs.ucsb.edu/)


### PR DESCRIPTION
Created an "Examples" page (as described on #34), renamed "Best Practice Examples" to "Best Practice Templates" to make it clear that they are different
