### PR TITLE
Add Gulp JS Minification Task and Developer README

### DIFF
--- a/README-DEVELOPER.md
+++ b/README-DEVELOPER.md
@@ -1,0 +1,27 @@
+# UCSB Web Standards Guide Development
+
+The UCSB Web Standards Guide is a static site generated with
+[Jekyll](http://jekyllrb.com/). As a result, updates to the site content
+can be made by simply modifying the [Markdown](https://help.github.com/articles/github-flavored-markdown/)
+files in the root directory.
+
+However, if you would like to fully build and host the website on your local
+machine, you can follow the directions below:
+
+## Prerequisites
+
+You will need to install the following to run all of the build steps
+associated with hosting the UCSB Web Standards Guide on your local machine:
+
+1. [Jekyll](http://jekyllrb.com/), used to generate the site from static Markdown files
+2. [Node.js](https://nodejs.org/), used to run automated build steps
+
+## Building the Web Standards Guide
+
+1. Clone the git repository: `git clone https://github.com/ucsb-wsg/ucsb-wsg.github.io.git`
+2. Run `npm install` to install all the required node.js dependencies
+3. Run `gulp` to minify JavaScript files
+4. Run `jekyll build` to generate the site
+5. Run `jekyll serve` to host the site locally
+
+You can now view the site [http://localhost:4000/](http://localhost:4000/).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,15 @@
+var del = require('del');
+var gulp = require('gulp');
+var uglify = require('gulp-uglify');
+var rename = require('gulp-rename');
+
+gulp.task('default', ['minify-js']);
+
+gulp.task('minify-js', function () {
+
+  gulp.src(['./scripts/*.js', '!./scripts/*.min.js'])
+    .pipe(uglify())
+    .pipe(rename({suffix: '.min'}))
+    .pipe(gulp.dest('./scripts/'));
+
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "url": "https://github.com/loganfranken/ucsb-wsg.github.io/issues"
   },
   "homepage": "https://github.com/loganfranken/ucsb-wsg.github.io",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "del": "^1.2.0",
+    "gulp": "^3.9.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-uglify": "^1.2.0",
     "uglify-js": "^2.4.23"
   }
 }


### PR DESCRIPTION
Added a Gulp task to do the JavaScript minification and a developer README to help with getting the site up and running locally.

I would like to find a way to run the `jekyll serve` and `jekyll watch` commands via `gulp` (so that everything gets done in one command), but I can create a separate issue for that.
