### PR TITLE
Revise web analytics policy

### DIFF
--- a/browsers.md
+++ b/browsers.md
@@ -8,10 +8,9 @@ permalink: /browsers/
 the browsers that approximately 90% of your website's visitors use. Please
 note that the usage statistics for your website may vary from the statistics
 cited here. Website maintainers may want to consider using web analytics tools
-to analyze traffic statistics for their site. Website managers should make
-sure that any chosen analytics tool complies with UC and UCSB policies
-(Google Analytics' third party indemnification clause does not comply as of
-2013).
+to analyze traffic statistics for their site.
+
+As of June 2015 UCSB policy allows the use of Google Analytics for tracking website visitor statistics. But, departments and entities [using Google Analytics should abide by the procedures outlined by the announcement of campus support of Google Analytics and other click-thru agreements](http://www.policy.ucsb.edu/policies/advisory-docs/clickthrough-guide.pdf).
 
 ### Vendor Requirements
 

--- a/browsers.md
+++ b/browsers.md
@@ -12,6 +12,8 @@ to analyze traffic statistics for their site.
 
 As of June 2015 UCSB policy allows the use of Google Analytics for tracking website visitor statistics. But, departments and entities [using Google Analytics should abide by the procedures outlined by the announcement of campus support of Google Analytics and other click-thru agreements](http://www.policy.ucsb.edu/policies/advisory-docs/clickthrough-guide.pdf).
 
+While Google Analytics may be used on campus websites, the [UCSB Enterprise Technology Services offers the Piwik Analytics Platform as a service to campus entities](http://www.ets.ucsb.edu/services/ets-web-analytics) as a centrally hosted, on-campus alternative to a 3rd party vendor service.
+
 ### Vendor Requirements
 
 The standards described on this page may be used for vendor requirements.


### PR DESCRIPTION
I have updated the text for the GA policy revision from June 2015.

I make it a point to say the WSG does not mandate or itself set the policy on GA. Rather, I say if you choose to use GA -- then follow the campus policy outlined in the official PDF. I also see not point in copying the text of the PDF into the Webguide as it would be incumbant on the WSG to keep up with revisions to this document; so I simply linked the document.
