### PR TITLE
Create sitemaps xml for github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,10 @@ url: "http://webguide.ucsb.edu/"
 twitter_username: ucsantabarbara
 github_username:  ucsb-wsg
 
+# Add support for githubpages sitemap.xml.
+gems:
+  - jekyll-sitemap
+
 # Build settings
 markdown: redcarpet
 


### PR DESCRIPTION
To help the site index faster at google I assume we'll try this out. I didn't test this locally as I assume the pages it's grabs will be sufficient. See my commit message to see how to exclude page(s) if necessary. I don't see an easy means to modify a pages' priority using front-matter at this time.

My goal is to submit this sitemap to google for indexing so the ucsb.edu GCS index is updated faster :smiley: 

References #51 
