### PR TITLE
Removed redcarpet as Markdown parser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,11 +15,6 @@ gems:
   - jekyll-sitemap
 
 # Build settings
-markdown: redcarpet
-
-redcarpet:
-    extensions: [with_toc_data]
-
 sass:
     style: :compressed
 


### PR DESCRIPTION
Per the [GitHub pages upgrade](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0), Redcarpet is no longer a supported Markdown parser. This commit removes that setting.

Fixes #97
