### PR TITLE
Remove meta http-equiv.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="The UCSB Web Standards Guide is a guide to building semantic, accessible, and standards-compliant websites and web applications for the University of California, Santa Barbara">


### PR DESCRIPTION
Fix W3C validation Error: A document must not include both a meta element with an http-equiv attribute whose value is content-type, and a meta element with a charset attribute.

![image](https://user-images.githubusercontent.com/4443025/29589179-1c8ae0a0-8749-11e7-8b36-efba311ac2d8.png)
