### PR TITLE
Remove role=contentinfo from footer tag

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="container" id="footer" role="contentinfo" aria-label="footer">
+<footer class="container" id="footer" aria-label="footer">
 <h2>WEBGUIDE</h2>
     <ul class="footer-nav row">
     <li class="col-ms-6 col-sm-2 "><a href="{{ "site-map" | relative_url }}">Site Map</a></li>


### PR DESCRIPTION
Fix W3C Warning: The contentinfo role is unnecessary for element footer.

![image](https://user-images.githubusercontent.com/4443025/29589166-0b289e42-8749-11e7-8fd8-7975d2bf4a6e.png)
