### PR TITLE
Remove role=banner from header tag.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 <body>
 
   <a href="http://webguide.ucsb.edu/#content" class="sr-only sr-only-focusable skip-to-content">Skip to content</a>
-  <header role="banner">
+  <header>
       <div class="navbar navbar-default yamm">
       <div class="navbar-header navbar-fixed-top">
 


### PR DESCRIPTION
Fix W3C Warning: The banner role is unnecessary for element header.

![image](https://user-images.githubusercontent.com/4443025/29589149-f8ff2d62-8748-11e7-8cb7-bbd46b9e15c1.png)
