### PR TITLE
Added Notes About Client-side Libraries to Developer README

### DIFF
--- a/README-DEVELOPER.md
+++ b/README-DEVELOPER.md
@@ -28,3 +28,15 @@ associated with hosting the UCSB Web Standards Guide on your local machine:
 4. Run `gulp` to generate the site and host it locally
 
 You can now view the site [http://localhost:4000/](http://localhost:4000/).
+
+## Client-side Libraries Used
+
+The web guide makes use of the following client-side libraries:
+
+* [Bootstrap](http://getbootstrap.com/) (v3.3.5)
+* [jQuery](https://jquery.com/) (v3.1.0)
+
+Most of these client-side libraries are served locally, rather than via a
+content delivery network (CDN).
+
+[Sass](http://sass-lang.com/) is used to write CSS.


### PR DESCRIPTION
Fixes #261 

Content sourced from:
https://github.com/ucsb-wsg/ucsb-wsg.github.io/wiki/2016-Theme-Update-Writeup

I didn't include the following:

* List of breakpoints used
* Note about the five significant figure decimal points

(Although I'm totally open to including them if the group thinks it's necessary)

And I'll open a ticket about the following:

"used some vendor prefixes such as -moz-border-radius, where maybe none should be used and ideally at later date the AutoPrefixer tool is used."