### PR TITLE
305 custom 404 page

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: 404 NOT FOUND
+permalink: /404.html
+---
+
+Oops, the resource you're looking for could not be found. Please use the site search or menu to find the content. If you believe this message to be in error <a href="mailto:wsg-chairs@connect.ucsb.edu">please send an E-mail inquiry to the WSG Co-Chairs with your request</a>.

--- a/404.md
+++ b/404.md
@@ -4,4 +4,4 @@ title: 404 NOT FOUND
 permalink: /404.html
 ---
 
-Oops, the resource you're looking for could not be found. Please use the site search or menu to find the content. If you believe this message to be in error <a href="mailto:wsg-chairs@connect.ucsb.edu">please send an E-mail inquiry to the WSG Co-Chairs with your request</a>.
+Oops, the resource you're looking for could not be found. Please use the site search or menu to find the content. If you believe this message to be in error <a href="mailto:wsg-chairs@connect.ucsb.edu">please send an Email to the UC Santa Barbara Web Standards Group Co-Chairs with your request</a>.

--- a/404.md
+++ b/404.md
@@ -4,4 +4,4 @@ title: 404 NOT FOUND
 permalink: /404.html
 ---
 
-Oops, the resource you're looking for could not be found. Please use the site search or menu to find the content. If you believe this message to be in error <a href="mailto:wsg-chairs@connect.ucsb.edu">please send an Email to the UC Santa Barbara Web Standards Group Co-Chairs with your request</a>.
+Oops, the resource you're looking for could not be found. Please use the site search or menu to find the content. If you believe this message to be in error <a href="mailto:wsg-chairs@connect.ucsb.edu">please send an Email to the UC Santa Barbara Web Standards Group co-chairs with your request</a>.


### PR DESCRIPTION
A simple pass at a basic 404 page for the webguide. It should simply take effect on the live site, it is not integrated into the site menu for obvious reasons.

fixes #305 