### PR TITLE
Update http => https refs for webguide.ucsb.edu Closes #328

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Through this migration, the Guide's URL was changed from http://www.ucsb.edu/web
 
 In February 2018, the repository for the guide was moved from the "UCSB Web Standards Group" GitHub organization to the "UC Santa Barbara" GitHub organization.
 
+In May 2018 [https://blog.github.com/2018-05-01-github-pages-custom-domains-https/](GitHub began supporting HTTPS for custom domains) by using [https://letsencrypt.org/](Let's Encrypt) which allowed the site to be hosted at https://webguide.ucsb.edu/
+
 ## Organization and Repository Management Between Co-Chairs
 
 Each of the two Web Standards Group Co-Chairs should have "Owner" permissions over the Web Standards Guide repository.

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >
   The UCSB Web Standards Guide is a guide to building semantic, accessible,
   and standards-compliant websites and web applications for the
   University of California, Santa Barbara
-url: "http://webguide.ucsb.edu/"
+url: "https://webguide.ucsb.edu/"
 twitter_username: ucsantabarbara
 github_username:  ucsb-wsg
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 
 <body>
 
-  <a href="http://webguide.ucsb.edu/#content" class="sr-only sr-only-focusable skip-to-content">Skip to content</a>
+  <a href="#content" class="sr-only sr-only-focusable skip-to-content">Skip to content</a>
   <header>
       <div class="navbar navbar-default yamm">
       <div class="navbar-header navbar-fixed-top">

--- a/campus-resources.md
+++ b/campus-resources.md
@@ -20,7 +20,7 @@ sections.
 
 Any individual seeking clarification or with an inquiry regarding web standards or best practices is encouraged to post their inquiry in the Github Issues Tracker which is actively moderated by the WSG Co-Chairs and WSG members. Please note that the Github platform requires a user account, by participating on Github your inquiries and responses will be in the public domain. Please observe proper etiquette and be respectful of others.
 
-### [UCSB-Web Mailing List](http://webguide.ucsb.edu/contact/#join-mailing-list)
+### [UCSB-Web Mailing List](https://webguide.ucsb.edu/contact/#join-mailing-list)
 
 Provides a forum for UCSB web professionals to exchange information about web
 design, development, best practices, and other web-related topics at UCSB. Web

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/ucsb-wsg/ucsb-wsg.github.io/issues"
   },
-  "homepage": "http://webguide.ucsb.edu/",
+  "homepage": "https://webguide.ucsb.edu/",
   "dependencies": {},
   "devDependencies": {
     "autoprefixer": "^6.5.3",


### PR DESCRIPTION
Changed every reference to http://webguide.ucsb.edu to https://webguide.ucsb.edu.

Also the Enforce HTTPS setting needs to be turned on.

https://github.com/UCSantaBarbara/webguide/settings

![image](https://user-images.githubusercontent.com/4443025/39665964-003be8f0-5051-11e8-9b5f-5d727f4a67bd.png)

